### PR TITLE
DST fix

### DIFF
--- a/HoursViewController.h
+++ b/HoursViewController.h
@@ -10,6 +10,8 @@
 
 @interface HoursViewController : UITableViewController
 
+@property (nonatomic) NSInteger currentWeekday;
+@property (nonatomic) NSInteger numberOfMinutesPastMidnight;
 @property (strong, nonatomic) IBOutlet UITableView *tableView;
 
 //***************************

--- a/HoursViewController.m
+++ b/HoursViewController.m
@@ -90,19 +90,6 @@ enum numberOfMinutesPastMidnightType : NSInteger {
 
 - (void)viewDidLoad
 {
-    [super viewDidLoad];
-}
-
-- (void)viewWillDisappear:(BOOL)animated
-{
-    [super viewWillDisappear:animated];
-    
-    // Clear selection of rows
-    [tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:animated];
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    
     //Initialize a calendar
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
     
@@ -132,9 +119,8 @@ enum numberOfMinutesPastMidnightType : NSInteger {
     now = [calendar dateFromComponents:comp];
 
     //Assign the adjusted time components to the desired integer name
-    enum dayOfWeek currentWeekday = [comp weekday];
-    NSInteger numberOfMinutesPastMidnight = [diff minute];
-    
+    self.currentWeekday = [comp weekday];
+    self.numberOfMinutesPastMidnight = [diff minute];
     
     //Get the current date to show which days do not have service
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
@@ -150,10 +136,24 @@ enum numberOfMinutesPastMidnightType : NSInteger {
     NSString *todayIs = [NSString stringWithFormat:@"%@%@%ld", [calMonth stringFromDate:date], @" ", (long)day];
 
     
+    [super viewDidLoad];
+}
 
+- (void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+
+    // Clear selection of rows
+    [tableView deselectRowAtIndexPath:[tableView indexPathForSelectedRow] animated:animated];
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
     UITableViewCell *cell = [super tableView:tableView cellForRowAtIndexPath:indexPath];
-    if (indexPath.row == 0 && indexPath.section == 0){
+    NSInteger currentWeekday = self.currentWeekday;
+    NSInteger numberOfMinutesPastMidnight = self.numberOfMinutesPastMidnight;
         
+    if (indexPath.row == 0 && indexPath.section == 0) {
         //////////////////////////
         // Stav Hall Calculations
         //////////////////////////

--- a/HoursViewController.m
+++ b/HoursViewController.m
@@ -94,47 +94,20 @@ enum numberOfMinutesPastMidnightType : NSInteger {
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
 
     //Assign the time zone we want
-    NSTimeZone *zone = [NSTimeZone timeZoneWithName:@"CST"];
-
-    //Get the current time
-    NSDate *now = [[NSDate alloc] init];
-
-    //Force the timzone on our calendar object
-    [calendar setTimeZone:zone];
-
-    //Set up the necessary date components we want to use
-    NSDateComponents *comp = [calendar components:(NSWeekdayCalendarUnit) fromDate:now];
+    [calendar setTimeZone:[NSTimeZone timeZoneWithName:@"CST"]];
 
     //Set up our tracker for seconds after midnight
-    NSDate *date = [NSDate date];
-    NSDateComponents *components = [calendar components:NSIntegerMax fromDate:date];
-    [components setHour:0];
-    [components setMinute:0];
-    [components setSecond:0];
+    NSDate *now = [NSDate date];
+    unsigned int unitFlags =  NSHourCalendarUnit | NSMinuteCalendarUnit | NSWeekdayCalendarUnit;
+    NSDateComponents *components = [calendar components:unitFlags fromDate:now];
 
-    NSDate *midnight = [[NSCalendar currentCalendar] dateFromComponents:components];
-    NSDateComponents *diff = [[NSCalendar currentCalendar] components:NSMinuteCalendarUnit fromDate:midnight toDate:date options:0];
-
-    //Adjust what "now" is and take the componesnts from them
-    now = [calendar dateFromComponents:comp];
+    // Just take the number of hours and minutes, and multiply them together ourselves.
+    self.numberOfMinutesPastMidnight = 60 * [components hour] + [components minute];
 
     //Assign the adjusted time components to the desired integer name
-    self.currentWeekday = [comp weekday];
-    self.numberOfMinutesPastMidnight = [diff minute];
-
-    //Get the current date to show which days do not have service
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateFormat:@"dd MMM, yyy"];
-    NSInteger units = NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit | NSWeekdayCalendarUnit;
-    NSDateComponents *components2 = [calendar components:units fromDate:date];
-    NSInteger day = [components2 day];
-    NSDateFormatter *weekDay = [[NSDateFormatter alloc] init];
-    [weekDay setDateFormat:@"EEE,"];
-    NSDateFormatter *calMonth = [[NSDateFormatter alloc] init];
-    [calMonth setDateFormat:@"MMM"];
-
-    NSString *todayIs = [NSString stringWithFormat:@"%@%@%ld", [calMonth stringFromDate:date], @" ", (long)day];
-
+    self.currentWeekday = [components weekday];
+    //NSLog(@"Minutes past midnight: %ld", (long)self.numberOfMinutesPastMidnight);
+    //NSLog(@"Day of week: %ld", (long)self.currentWeekday);
 
     [super viewDidLoad];
 }

--- a/HoursViewController.m
+++ b/HoursViewController.m
@@ -92,36 +92,36 @@ enum numberOfMinutesPastMidnightType : NSInteger {
 {
     //Initialize a calendar
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar];
-    
+
     //Assign the time zone we want
     NSTimeZone *zone = [NSTimeZone timeZoneWithName:@"CST"];
-    
+
     //Get the current time
     NSDate *now = [[NSDate alloc] init];
 
     //Force the timzone on our calendar object
     [calendar setTimeZone:zone];
-    
+
     //Set up the necessary date components we want to use
     NSDateComponents *comp = [calendar components:(NSWeekdayCalendarUnit) fromDate:now];
-    
+
     //Set up our tracker for seconds after midnight
     NSDate *date = [NSDate date];
     NSDateComponents *components = [calendar components:NSIntegerMax fromDate:date];
     [components setHour:0];
     [components setMinute:0];
     [components setSecond:0];
-    
+
     NSDate *midnight = [[NSCalendar currentCalendar] dateFromComponents:components];
     NSDateComponents *diff = [[NSCalendar currentCalendar] components:NSMinuteCalendarUnit fromDate:midnight toDate:date options:0];
-    
+
     //Adjust what "now" is and take the componesnts from them
     now = [calendar dateFromComponents:comp];
 
     //Assign the adjusted time components to the desired integer name
     self.currentWeekday = [comp weekday];
     self.numberOfMinutesPastMidnight = [diff minute];
-    
+
     //Get the current date to show which days do not have service
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setDateFormat:@"dd MMM, yyy"];
@@ -132,10 +132,10 @@ enum numberOfMinutesPastMidnightType : NSInteger {
     [weekDay setDateFormat:@"EEE,"];
     NSDateFormatter *calMonth = [[NSDateFormatter alloc] init];
     [calMonth setDateFormat:@"MMM"];
-    
+
     NSString *todayIs = [NSString stringWithFormat:@"%@%@%ld", [calMonth stringFromDate:date], @" ", (long)day];
 
-    
+
     [super viewDidLoad];
 }
 
@@ -152,14 +152,14 @@ enum numberOfMinutesPastMidnightType : NSInteger {
     UITableViewCell *cell = [super tableView:tableView cellForRowAtIndexPath:indexPath];
     NSInteger currentWeekday = self.currentWeekday;
     NSInteger numberOfMinutesPastMidnight = self.numberOfMinutesPastMidnight;
-        
+
     if (indexPath.row == 0 && indexPath.section == 0) {
         //////////////////////////
         // Stav Hall Calculations
         //////////////////////////
-        
+
         //Mon-Fri
-        if(currentWeekday == Monday || currentWeekday == Tuesday || currentWeekday == Wednesday || currentWeekday == Thursday || currentWeekday == Friday)
+        if (currentWeekday == Monday || currentWeekday == Tuesday || currentWeekday == Wednesday || currentWeekday == Thursday || currentWeekday == Friday)
         {
 
             //Closing soon


### PR DESCRIPTION
A few changes here:
1. Only compute `minutesSinceMidnight` once per view load
   - Is this OK?
2. Manually compute the minutes since midnight.
   - Only pull the relevant bits out of the NSDateComponents, and just multiply them manually.
   - It looks like it's up the consumer of the date diff to do something smart with DST, because a formatted date came out right.
